### PR TITLE
Add Retrieve Closed Candidate Profile to the Postman collection

### DIFF
--- a/postman-collection/Recruiter System Connect.postman_collection.json
+++ b/postman-collection/Recruiter System Connect.postman_collection.json
@@ -2218,6 +2218,60 @@
 					],
 					"protocolProfileBehavior": {},
 					"_postman_isSubFolder": true
+				},
+				{
+					"name": "Retrieve Closed Candidate Profiles",
+					"item": [
+						{
+							"name": "GET Closed Candidate Profiles",
+							"request": {
+								"auth": {
+									"type": "bearer",
+									"bearer": [
+										{
+											"key": "token",
+											"value": "{{customer_access_token}}",
+											"type": "string"
+										}
+									]
+								},
+								"method": "GET",
+								"header": [],
+								"url": {
+									"raw": "https://api.linkedin.com/v2/atsPurgedExportedCandidates?timeRange.start=1589747047000&timeRange.end=1592425447000&q=criteria&exportType=ONE_CLICK_EXPORT",
+									"protocol": "https",
+									"host": [
+										"api",
+										"linkedin",
+										"com"
+									],
+									"path": [
+										"v2",
+										"atsPurgedExportedCandidates"
+									],
+									"query": [
+										{
+											"key": "timeRange.start",
+											"value": "1589747047000"
+										},
+										{
+											"key": "timeRange.end",
+											"value": "1592425447000"
+										},
+										{
+											"key": "q",
+											"value": "criteria"
+										},
+										{
+											"key": "exportType",
+											"value": "ONE_CLICK_EXPORT"
+										}
+									]
+								}
+							},
+							"response": []
+						}
+					]
 				}
 			],
 			"protocolProfileBehavior": {}


### PR DESCRIPTION
# Retrieve Closed Candidate Profile
Retrieving closed candidate profile is not in the Postman collection, so this PR adds it to the collection
Documentation can be found [here](https://docs.microsoft.com/en-us/linkedin/talent/recruiter-system-connect/retrieve-exported-candidates#retrieving-closed-candidate-profiles)

## Changes
- Added a sample request to retrieve Closed Candidate Profile to the postman collection
 